### PR TITLE
Update ANDROID-RPI.md

### DIFF
--- a/ANDROID-RPI.md
+++ b/ANDROID-RPI.md
@@ -8,7 +8,7 @@ Project page - https://glodroid.github.io/
     ```
       mkdir -p android-rpi
       cd android-rpi
-      repo init -u https://android.googlesource.com/platform/manifest -b android-12.0.0_r27
+      repo init -u https://android.googlesource.com/platform/manifest -b android-12.1.0_r21
       git clone https://github.com/android-rpi/local_manifests .repo/local_manifests -b arpi-12
       repo sync
       source ./build/envsetup.sh


### PR DESCRIPTION
    Android branch should be updated to android-12.1.0_r21
    
    Android branch should be updated to android-12.1.0_r21 to avoid
    compilation erros on
    .../frameworks/av/media/libeffects/downmix/EffectDownmix.cpp
    because it cannot find audio_utils/ChannelMix.h file.
    Same was done on device_arpi_rpi4 (original project)